### PR TITLE
Pass simple nodes to benchmark graph

### DIFF
--- a/ros2_benchmark/ros2_benchmark/ros2_benchmark_test.py
+++ b/ros2_benchmark/ros2_benchmark/ros2_benchmark_test.py
@@ -192,7 +192,7 @@ class ROS2BenchmarkTest(unittest.TestCase):
 
     @classmethod
     def generate_test_description_with_nsys(cls,
-        launch_setup, node_startup_delay: float = 5.0
+        launch_setup, simple_nodes = [], node_startup_delay: float = 5.0
     ) -> launch.LaunchDescription:
         """Generate a test launch description with the nsys capability built in."""
         launch_args = NsysUtility.generate_launch_args()
@@ -222,7 +222,7 @@ class ROS2BenchmarkTest(unittest.TestCase):
         
         
         return launch.LaunchDescription(
-            nodes + [trace] + [
+            nodes + [trace] + simple_nodes + [
                 # Start tests after a fixed delay for node startup
                 launch.actions.TimerAction(
                     period=node_startup_delay,


### PR DESCRIPTION
This PR lets the user pass `Node`s to `ros2_benchmark`, instead of being forced to create a `Component` and add it to a `ComposableNodeContainer`.

Thus, the `generate_test_description_with_nsys` accepts these parameters:
1. `launch_setup`: a list of `ComposableNodeContainer`s.
2. [new] `simple_nodes`: a list of `Node`s.
3. `node_startup_delay`

Since `simple_nodes` is initialized as an empty list, it won't affect the launch files written before this PR.